### PR TITLE
[MDS-223] Gracefully handle missing date keys from trade leads feed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
           command: |
             . venv/bin/activate
             flake8
-            python -m pytest --disable-pytest-warnings --cov=. --cov-report=html:/tmp/test-artifacts/coverage --cov-fail-under=93 --junitxml=/tmp/test-results/pytest.xml
+            python -m pytest --disable-pytest-warnings --cov-fail-under=96 --cov=. --cov-report=html:/tmp/test-artifacts/coverage --junitxml=/tmp/test-results/pytest.xml
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,4 +4,5 @@ flake8-formatter-junit-xml==0.0.6
 flake8-import-order==0.18.1
 pytest==5.4.1
 pytest-cov==2.8.1
+pytest-mock==2.0.0
 vcrpy==4.0.2

--- a/test_service.py
+++ b/test_service.py
@@ -29,5 +29,5 @@ def test_handler_handles_parse_error(mocker):
 
 
 def test_normalize_date_handles_missing_field():
-    """Ensures any mossing date fields get represented as None"""
+    """Ensures any missing date fields get represented as None"""
     assert normalize_date({'open_date': '10/10/2020'}, 'close_date') is None

--- a/test_service.py
+++ b/test_service.py
@@ -1,6 +1,8 @@
+import xml
+
 import vcr
 
-from service import get_entries
+from service import get_entries, handler, normalize_date
 
 
 @vcr.use_cassette()
@@ -18,3 +20,14 @@ def test_get_entries():
         "url": "https://ustda.gov/business-opportunities/trade-leads/high-definition-data",
     }
     assert entries[0] == expected_entry
+
+
+def test_handler_handles_parse_error(mocker):
+    """Ensures any XML parsing issues from garbage input get ignored"""
+    mocker.patch('service.get_entries', side_effect=xml.etree.ElementTree.ParseError)
+    assert handler(None, None) is False
+
+
+def test_normalize_date_handles_missing_field():
+    """Ensures any mossing date fields get represented as None"""
+    assert normalize_date({'open_date': '10/10/2020'}, 'close_date') is None


### PR DESCRIPTION
- Turn missing date fields into `None`
- Handle malformed XML
- Increased test coverage
- Also handle boto3 ClientError